### PR TITLE
Handle cross-filesystem plugin move with shutil rather than rename.

### DIFF
--- a/vire.py
+++ b/vire.py
@@ -357,7 +357,7 @@ def get_plugin(reponame, location=None):
             files.extend(dotfiles)
             os.mkdir(pluginpath)
             for pfs in files:
-                os.rename(pfs, pfs.replace(renamed, pluginpath))
+                shutil.move(pfs, pfs.replace(renamed, pluginpath))
             try:
                 os.remove(renamed)
                 os.remove(zextract)


### PR DESCRIPTION
`os.rename` gives a `OSError: [Errno 18] Invalid cross-device link` if `/tmp` is on a different file system than the destination (e.g. home directory), while `shutil.move` does not. [stack overflow reference](https://stackoverflow.com/a/43967659/14282783)

This is a common set up on computing infrastructure, such as at academic research institutions and others.

I really like the idea behind this vim package manager. Thanks for providing it!

Cheers,

Ed